### PR TITLE
Update nodejs and mongodb tasks and other small updates

### DIFF
--- a/tasks_jetbrains_pycharm_community.yml
+++ b/tasks_jetbrains_pycharm_community.yml
@@ -70,7 +70,7 @@
       src={{apps_dir}}/pycharm/bin/pycharm.sh
       dest=/usr/bin/pycharm
       state=link
-    sudo: yes
+    become: yes
     tags:
       -jetbrains
       -pycharm

--- a/tasks_mongodb_3.yml
+++ b/tasks_mongodb_3.yml
@@ -19,7 +19,7 @@
       - mongodb3
 
   - name: MongoDB | Add Debian apt repository
-    apt_repository: repo="deb http://repo.mongodb.org/apt/ubuntu {{ apt_source.mongodb }}/mongodb-org/3.0 multiverse"
+    apt_repository: repo="deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/3.4 multiverse"
     when: ansible_os_family == "Debian" and mongo_present|failed
     become: yes
     tags:

--- a/tasks_nodejs.yml
+++ b/tasks_nodejs.yml
@@ -55,7 +55,7 @@
 
   - name: NodeJS | Add NodeSource repository preferences
     template:
-      src: "{{role_dir}}/templates/nodejs/deb_nodesource_com_node.pref.j2"
+      src: "{{root_dir}}/templates/nodejs/deb_nodesource_com_node.pref.j2"
       dest: /etc/apt/preferences.d/deb_nodesource_com_node.pref
     become: yes
     when: ansible_os_family == "Debian" and node_present|failed

--- a/tasks_nodejs.yml
+++ b/tasks_nodejs.yml
@@ -19,7 +19,7 @@
 
   - name: NodeJS | Check nodejs_version variable
     assert:
-      that: nodejs_version in [ "0.10", "0.12", "4.x", "5.x" ]
+      that: nodejs_version in [ "0.10", "0.12", "4.x", "5.x", "6.x", "7.x"  ]
     when: ansible_os_family == "Debian" and node_present|failed
     tags:
        -nodejs
@@ -71,7 +71,7 @@
        -nodejs
        -setup
 
-  - name: NodeJS | Install Node.js 4.x 5.x family
+  - name: NodeJS | Install Node.js 4.x 5.x 6.x 7.x family
     apt: pkg=nodejs state=installed update_cache=yes
     become: yes
     when: ansible_os_family == "Debian" and nodejs_version not in [ "0.10", "0.12" ]  and node_present|failed
@@ -88,7 +88,7 @@
        -setup
 
 
-  - name: NodeJS | Install gulp, bower, grunt, grunt-cli tools tool
+  - name: NodeJS | Install gulp, bower and other tools as globals
     shell: npm install -g {{ item }}
     when: ansible_os_family == "Debian" and node_present|failed
     with_items:

--- a/tasks_sendmail.yml
+++ b/tasks_sendmail.yml
@@ -1,0 +1,4 @@
+- name: Sendmail | Install Sendmail (Debian)
+  apt: pkg=sendmail state=installed
+  when: ansible_os_family == "Debian"
+  become: true

--- a/tasks_sendmail.yml
+++ b/tasks_sendmail.yml
@@ -1,4 +1,4 @@
 - name: Sendmail | Install Sendmail (Debian)
-  apt: pkg=sendmail state=installed
+  apt: pkg=sendmail state=installed update_cache=yes
   when: ansible_os_family == "Debian"
   become: true

--- a/uninstall/tasks_nodejs.yml
+++ b/uninstall/tasks_nodejs.yml
@@ -1,0 +1,14 @@
+- name: NodeJS | Remove Node.js 0.10 0.12 family
+  apt: pkg=nodejs={{ nodejs_version }}.* state=absent update_cache=yes
+  become: yes
+  when: ansible_os_family == "Debian" and nodejs_version in [ "0.10", "0.12" ]
+  tags:
+     -nodejs
+     -setup
+- name: NodeJS | Remove Node.js 4.x 5.x 6.x 7.x family
+  apt: pkg=nodejs state=absent update_cache=yes
+  become: yes
+  when: ansible_os_family == "Debian" and nodejs_version not in [ "0.10", "0.12" ]
+  tags:
+     -nodejs
+     -setup

--- a/vagrant/tasks_vagrant_php_xdebug.yml
+++ b/vagrant/tasks_vagrant_php_xdebug.yml
@@ -105,7 +105,7 @@
 
 - name: XDebug | Errors to browser
   template:
-    src: "{{role_dir}}/files/php_debug/devbox.ini.j2"
+    src: "{{root_dir}}/files/php_debug/devbox.ini.j2"
     dest: "{{ php_extension_conf_path.stdout.replace('/cli/','/apache2/') }}/devbox.ini"
     owner: root
     group: root
@@ -123,7 +123,7 @@
 
 - name: XDebug | Errors to browser
   template:
-    src: "{{role_dir}}/files/php_debug/devbox.ini.j2"
+    src: "{{root_dir}}/files/php_debug/devbox.ini.j2"
     dest: "{{ php_extension_conf_path.stdout.replace('/cli/','/fpm/') }}/devbox.ini"
     owner: root
     group: root


### PR DESCRIPTION
This PR include the following:
- Update available versions in nodejs task to include 6.x and 7.x families
- Update version of mongodb to 3.4 and use `ansible_distribution_release` instead of `apt_source.mongodb`. If using within the lamp-box repo, it throws a `var not found` error. (Asuming this source: https://jira.mongodb.org/browse/SERVER-24634 to be reason to use different version in xenial release).
- Adds a Sendmail task
- Adds an uninstall nodejs task, if required.
- Update var to `root_dir` instead of `role_dir` in nodejs and xdebug tasks. If using within the lamp-box repo, it throws a `var not found` error.
- Update ansible syntax to use `become`

My environment for testing these changes is:
```
Vagrant 1.9.1
ansible 2.2.1.0
```

The next files are missing, so if using with lamp-box it throws a `file not found` error:
```
/vagrant/tasks_vagrant_php_webgrind.yml
/vagrant/tasks_vagrant_phpmyadmin.yml
```

Thanks for this work, I'm currently working on top of this in conjunction with the lamp-box repo.